### PR TITLE
Refactor LCD library to PEP8 standards

### DIFF
--- a/I2C_LCD_driver.py
+++ b/I2C_LCD_driver.py
@@ -15,46 +15,54 @@ Made available under GNU GENERAL PUBLIC LICENSE
 
 """
 
+import smbus
+from time import sleep
+
+
 # i2c bus (0 -- original Pi, 1 -- Rev 2 Pi)
 I2CBUS = 1
 
 # LCD Address
 ADDRESS = 0x27
 
-import smbus
-from time import sleep
 
-class i2c_device:
-   def __init__(self, addr, port=I2CBUS):
-      self.addr = addr
-      self.bus = smbus.SMBus(port)
+class I2CDevice:
+    def __init__(self, addr, port=I2CBUS):
+        self.addr = addr
+        self.bus = smbus.SMBus(port)
 
-# Write a single command
-   def write_cmd(self, cmd):
-      self.bus.write_byte(self.addr, cmd)
-      sleep(0.0001)
+    def write_cmd(self, cmd):
+        '''Write a single command'''
 
-# Write a command and argument
-   def write_cmd_arg(self, cmd, data):
-      self.bus.write_byte_data(self.addr, cmd, data)
-      sleep(0.0001)
+        self.bus.write_byte(self.addr, cmd)
+        sleep(0.0001)
 
-# Write a block of data
-   def write_block_data(self, cmd, data):
-      self.bus.write_block_data(self.addr, cmd, data)
-      sleep(0.0001)
+    def write_cmd_arg(self, cmd, data):
+        '''Write a command and argument'''
 
-# Read a single byte
-   def read(self):
-      return self.bus.read_byte(self.addr)
+        self.bus.write_byte_data(self.addr, cmd, data)
+        sleep(0.0001)
 
-# Read
-   def read_data(self, cmd):
-      return self.bus.read_byte_data(self.addr, cmd)
+    def write_block_data(self, cmd, data):
+        '''Write a block of data'''
 
-# Read a block of data
-   def read_block_data(self, cmd):
-      return self.bus.read_block_data(self.addr, cmd)
+        self.bus.write_block_data(self.addr, cmd, data)
+        sleep(0.0001)
+
+    def read(self):
+        '''Read a single byte'''
+
+        return self.bus.read_byte(self.addr)
+
+    def read_data(self, cmd):
+        '''Read'''
+
+        return self.bus.read_byte_data(self.addr, cmd)
+
+    def read_block_data(self, cmd):
+        '''Read a block of data'''
+
+        return self.bus.read_block_data(self.addr, cmd)
 
 
 # commands
@@ -99,81 +107,91 @@ LCD_5x8DOTS = 0x00
 LCD_BACKLIGHT = 0x08
 LCD_NOBACKLIGHT = 0x00
 
-En = 0b00000100 # Enable bit
-Rw = 0b00000010 # Read/Write bit
-Rs = 0b00000001 # Register select bit
-
-class lcd:
-   #initializes objects and lcd
-   def __init__(self):
-      self.lcd_device = i2c_device(ADDRESS)
-
-      self.lcd_write(0x03)
-      self.lcd_write(0x03)
-      self.lcd_write(0x03)
-      self.lcd_write(0x02)
-
-      self.lcd_write(LCD_FUNCTIONSET | LCD_2LINE | LCD_5x8DOTS | LCD_4BITMODE)
-      self.lcd_write(LCD_DISPLAYCONTROL | LCD_DISPLAYON)
-      self.lcd_write(LCD_CLEARDISPLAY)
-      self.lcd_write(LCD_ENTRYMODESET | LCD_ENTRYLEFT)
-      sleep(0.2)
+En = 0b00000100  # Enable bit
+Rw = 0b00000010  # Read/Write bit
+Rs = 0b00000001  # Register select bit
 
 
-   # clocks EN to latch command
-   def lcd_strobe(self, data):
-      self.lcd_device.write_cmd(data | En | LCD_BACKLIGHT)
-      sleep(.0005)
-      self.lcd_device.write_cmd(((data & ~En) | LCD_BACKLIGHT))
-      sleep(.0001)
+class LCD:
+    def __init__(self):
+        self.device = I2CDevice(ADDRESS)
 
-   def lcd_write_four_bits(self, data):
-      self.lcd_device.write_cmd(data | LCD_BACKLIGHT)
-      self.lcd_strobe(data)
+        self.write(0x03)
+        self.write(0x03)
+        self.write(0x03)
+        self.write(0x02)
 
-   # write a command to lcd
-   def lcd_write(self, cmd, mode=0):
-      self.lcd_write_four_bits(mode | (cmd & 0xF0))
-      self.lcd_write_four_bits(mode | ((cmd << 4) & 0xF0))
+        self.write(LCD_FUNCTIONSET | LCD_2LINE | LCD_5x8DOTS | LCD_4BITMODE)
+        self.write(LCD_DISPLAYCONTROL | LCD_DISPLAYON)
+        self.write(LCD_CLEARDISPLAY)
+        self.write(LCD_ENTRYMODESET | LCD_ENTRYLEFT)
+        sleep(0.2)
 
-   # write a character to lcd (or character rom) 0x09: backlight | RS=DR<
-   # works!
-   def lcd_write_char(self, charvalue, mode=1):
-      self.lcd_write_four_bits(mode | (charvalue & 0xF0))
-      self.lcd_write_four_bits(mode | ((charvalue << 4) & 0xF0))
-  
-   # put string function with optional char positioning
-   def lcd_display_string(self, string, line=1, pos=0):
-    if line == 1:
-      pos_new = pos
-    elif line == 2:
-      pos_new = 0x40 + pos
-    elif line == 3:
-      pos_new = 0x14 + pos
-    elif line == 4:
-      pos_new = 0x54 + pos
+    def strobe(self, data):
+        '''clocks EN to latch command'''
 
-    self.lcd_write(0x80 + pos_new)
+        self.device.write_cmd(data | En | LCD_BACKLIGHT)
+        sleep(.0005)
+        self.device.write_cmd(((data & ~En) | LCD_BACKLIGHT))
+        sleep(.0001)
 
-    for char in string:
-      self.lcd_write(ord(char), Rs)
+    def write_four_bits(self, data):
+        self.device.write_cmd(data | LCD_BACKLIGHT)
+        self.strobe(data)
 
-   # clear lcd and set to home
-   def lcd_clear(self):
-      self.lcd_write(LCD_CLEARDISPLAY)
-      self.lcd_write(LCD_RETURNHOME)
+    def write(self, cmd, mode=0):
+        '''write a command to lcd'''
 
-   # define backlight on/off (lcd.backlight(1); off= lcd.backlight(0)
-   def backlight(self, state): # for state, 1 = on, 0 = off
-      if state == 1:
-         self.lcd_device.write_cmd(LCD_BACKLIGHT)
-      elif state == 0:
-         self.lcd_device.write_cmd(LCD_NOBACKLIGHT)
+        self.write_four_bits(mode | (cmd & 0xF0))
+        self.write_four_bits(mode | ((cmd << 4) & 0xF0))
 
-   # add custom characters (0 - 7)
-   def lcd_load_custom_chars(self, fontdata):
-      self.lcd_write(0x40);
-      for char in fontdata:
-         for line in char:
-            self.lcd_write_char(line)         
-         
+    def write_char(self, charvalue, mode=1):
+        '''write a character to lcd (or character rom)
+
+        0x09: backlight | RS=DR< works!
+
+        '''
+        self.write_four_bits(mode | (charvalue & 0xF0))
+        self.write_four_bits(mode | ((charvalue << 4) & 0xF0))
+
+    def display_string(self, string, line=1, pos=0):
+        '''put string function with optional char positioning'''
+
+        if line == 1:
+            pos_new = pos
+        elif line == 2:
+            pos_new = 0x40 + pos
+        elif line == 3:
+            pos_new = 0x14 + pos
+        elif line == 4:
+            pos_new = 0x54 + pos
+
+        self.write(0x80 + pos_new)
+
+        for char in string:
+            self.write(ord(char), Rs)
+
+    def clear(self):
+        '''clear lcd and set to home'''
+
+        self.write(LCD_CLEARDISPLAY)
+        self.write(LCD_RETURNHOME)
+
+    def backlight(self, state):
+        '''define backlight on/off
+
+            on = lcd.backlight(1)
+            off= lcd.backlight(0)
+        '''
+        if state == 1:
+            self.device.write_cmd(LCD_BACKLIGHT)
+        elif state == 0:
+            self.device.write_cmd(LCD_NOBACKLIGHT)
+
+    def load_custom_chars(self, fontdata):
+        '''add custom characters (0 - 7)'''
+
+        self.write(0x40)
+        for char in fontdata:
+            for line in char:
+                self.write_char(line)

--- a/mercury/__init__.py
+++ b/mercury/__init__.py
@@ -539,7 +539,7 @@ def redraw():
     while True:
         if not state.toggledisplay:
             try:
-                state.lcd.lcd_clear()
+                state.lcd.clear()
                 state.lcd.backlight(0)
             except BaseException:
                 pass

--- a/mercury/drawing.py
+++ b/mercury/drawing.py
@@ -1,4 +1,4 @@
-import I2C_LCD_driver as i2c_charLCD
+from I2C_LCD_driver import LCD
 
 from datetime import datetime
 from logging import error, warning, info, debug
@@ -19,9 +19,9 @@ def get_screen_element_name(i):
 def startlcd(state, retry=False):
     try:
         debug("Starting LCD display...")
-        lcd = i2c_charLCD.lcd()
+        lcd = LCD()
         lcd.backlight(1)
-        lcd.lcd_clear()
+        lcd.clear()
         info("Started LCD display.")
         state.drawlist[:] = [True, True, True, True, True]
     except BaseException as e:
@@ -43,7 +43,7 @@ def displayfail(state):
 
 def draw_heaterstatus(state, lcd):
     state_name = state.htrstatus.pretty_name
-    lcd.lcd_display_string(state_name.ljust(10), 1)
+    lcd.display_string(state_name.ljust(10), 1)
 
 
 def draw_time(state, lcd):
@@ -53,12 +53,12 @@ def draw_time(state, lcd):
         if not state.blinker:
             # blink colon off
             state.blinker = True
-            lcd.lcd_display_string(" ", 1, 17)
+            lcd.display_string(" ", 1, 17)
 
         else:
             # blink colon back on
             state.blinker = False
-            lcd.lcd_display_string(":", 1, 17)
+            lcd.display_string(":", 1, 17)
 
     else:
         state.displayed_time_last_refresh = monotonic()
@@ -68,14 +68,14 @@ def draw_time(state, lcd):
         else:
             localtime = datetime.now().strftime('%H:%M')
 
-        lcd.lcd_display_string(localtime.rjust(10), 1, 10)
+        lcd.display_string(localtime.rjust(10), 1, 10)
 
 
 def draw_temp(state, lcd):
     # tt = '{0:.1f}'.format(state.target_temp) + chr(223) + "C"
     tts = '{0:.1f}'.format(state.setpoint) + chr(223) + "C"
 
-    lcd.lcd_display_string(tts.center(20), 2)
+    lcd.display_string(tts.center(20), 2)
 
 
 def draw_sensor(state, lcd):
@@ -89,8 +89,8 @@ def draw_sensor(state, lcd):
     sensortemperature = '{0:.1f}'.format(sensortemp) + chr(223) + "C"
     sensorhumidity = '{0:.0f}'.format(sensorhumidity) + "%"
 
-    lcd.lcd_display_string(sensortemperature.ljust(6), 3)
-    lcd.lcd_display_string(sensorhumidity.ljust(6), 4)
+    lcd.display_string(sensortemperature.ljust(6), 3)
+    lcd.display_string(sensorhumidity.ljust(6), 4)
 
 
 def draw_weather(state, lcd):
@@ -107,6 +107,6 @@ def draw_weather(state, lcd):
         outhumidity = "---%"
 
     finally:
-        lcd.lcd_display_string(outtemp.rjust(5), 3, 15)
-        lcd.lcd_display_string(cc.ljust(8), 4, 7)
-        lcd.lcd_display_string(outhumidity.rjust(5), 4, 15)
+        lcd.display_string(outtemp.rjust(5), 3, 15)
+        lcd.display_string(cc.ljust(8), 4, 7)
+        lcd.display_string(outhumidity.rjust(5), 4, 15)


### PR DESCRIPTION
LCD library has been refactored, all `lcd_` prefixes have been removed
from the method names as they were redundant.

Eventually, I think that the LCD library should be integrated inside the
mercury package instead of residing at the root.